### PR TITLE
add codecov.io to ci and readme badge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ version: 2.1
             name: "Run coverage on Linux"
             command:
                 make cover
+        - run:
+            name: "Upload coverage to codecov"
+            command:
+                bash <(curl -s https://codecov.io/bash) -f build/coverage/coverage.txt
 
         - store_artifacts:
             path: build/coverage/coverage.html

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CircleCI](https://circleci.com/gh/cloudflare/circl/tree/master.svg?style=svg)](https://circleci.com/gh/cloudflare/circl/tree/master)
 [![GoDoc](https://godoc.org/github.com/cloudflare/circl?status.svg)](https://godoc.org/github.com/cloudflare/circl)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cloudflare/circl)](https://goreportcard.com/report/github.com/cloudflare/circl)
+[![codecov](https://codecov.io/gh/cloudflare/circl/branch/master/graph/badge.svg)](https://codecov.io/gh/cloudflare/circl)
 
 **CIRCL** (Cloudflare Interoperable, Reusable Cryptographic Library) is a collection
 of cryptographic primitives written in Go. The goal of this library is to be used as a tool for

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# Default codecoverage configuration https://docs.codecov.io/docs/codecov-yaml
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Add codecov.io support to circleCI and add badge to Readme.md.

Codecov.io can also be used to display code coverage reports as Pull Request comments.


[![codecov](https://codecov.io/gh/dougnukem/circl/branch/dougnukem/codecov/graph/badge.svg)](https://codecov.io/gh/dougnukem/circl/branch/dougnukem%2Fcodecov)

[![codecov_graph](https://codecov.io/gh/dougnukem/circl/branch/dougnukem/codecov/graphs/tree.svg)](https://codecov.io/gh/dougnukem/circl)

# Next Steps
- cloudflare/circl repository admins will need to authorize https://codecov.io/ to access repo
